### PR TITLE
Integrate frontend pages with backend API

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,210 @@
+import axios, { type AxiosError, type AxiosRequestConfig } from "axios";
+
+const rawBase = import.meta.env?.VITE_API_BASE || "http://127.0.0.1:8000";
+const API_BASE_URL = rawBase.replace(/\/$/, "");
+
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+
+const isBrowser = typeof window !== "undefined";
+
+const readToken = (key: string) => {
+  if (!isBrowser) return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn("Unable to read auth token", error);
+    return null;
+  }
+};
+
+const storeToken = (key: string, value?: string | null) => {
+  if (!isBrowser) return;
+  try {
+    if (value) {
+      window.localStorage.setItem(key, value);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.warn("Unable to persist auth token", error);
+  }
+};
+
+export const getAccessToken = () => readToken(ACCESS_TOKEN_KEY);
+export const getRefreshToken = () => readToken(REFRESH_TOKEN_KEY);
+
+export const setAuthTokens = (access: string, refresh?: string) => {
+  storeToken(ACCESS_TOKEN_KEY, access);
+  if (typeof refresh === "string") {
+    storeToken(REFRESH_TOKEN_KEY, refresh);
+  }
+};
+
+export const clearAuthTokens = () => {
+  storeToken(ACCESS_TOKEN_KEY, null);
+  storeToken(REFRESH_TOKEN_KEY, null);
+};
+
+export const endpoints = {
+  login: "/api/auth/login/",
+  refresh: "/api/auth/refresh/",
+  dashboardStats: "/api/dashboard/stats",
+  products: "/api/v1/products/",
+  productDetail: (id: number | string) => `/api/v1/products/${id}/`,
+  productArchive: (id: number | string) => `/api/v1/products/${id}/archive/`,
+  productRestore: (id: number | string) => `/api/v1/products/${id}/restore/`,
+  categories: "/api/v1/categories/",
+  categoryDetail: (id: number | string) => `/api/v1/categories/${id}/`,
+  customers: "/api/v1/customers/",
+  customerDetail: (id: number | string) => `/api/v1/customers/${id}/`,
+  customerArchive: (id: number | string) => `/api/v1/customers/${id}/archive/`,
+  customerRestore: (id: number | string) => `/api/v1/customers/${id}/restore/`,
+  invoices: "/api/v1/invoices/",
+  invoiceDetail: (id: number | string) => `/api/v1/invoices/${id}/`,
+  invoiceAddItem: (id: number | string) => `/api/v1/invoices/${id}/add_item/`,
+  invoiceConfirm: (id: number | string) => `/api/v1/invoices/${id}/confirm/`,
+  payments: "/api/v1/payments/",
+  balances: "/api/v1/balances/",
+} as const;
+
+export interface ApiListResponse<T> {
+  count?: number;
+  next?: string | null;
+  previous?: string | null;
+  results: T[];
+}
+
+export const normalizeListResponse = <T>(data: unknown): ApiListResponse<T> => {
+  if (Array.isArray(data)) {
+    return {
+      count: data.length,
+      next: null,
+      previous: null,
+      results: data as T[],
+    };
+  }
+
+  if (typeof data === "object" && data !== null) {
+    const cast = data as Record<string, unknown> & {
+      results?: T[];
+      count?: number;
+      next?: string | null;
+      previous?: string | null;
+    };
+
+    const results = Array.isArray(cast.results) ? cast.results : [];
+
+    return {
+      results,
+      count: typeof cast.count === "number" ? cast.count : results.length,
+      next: typeof cast.next === "string" ? cast.next : null,
+      previous: typeof cast.previous === "string" ? cast.previous : null,
+    };
+  }
+
+  return { count: 0, next: null, previous: null, results: [] };
+};
+
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+});
+
+type RetryableConfig = AxiosRequestConfig & { _retry?: boolean };
+
+apiClient.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  if (token && config.headers && !config.headers.Authorization) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+let isRefreshing = false;
+let refreshSubscribers: Array<(token: string | null) => void> = [];
+
+const subscribeTokenRefresh = (callback: (token: string | null) => void) => {
+  refreshSubscribers.push(callback);
+};
+
+const onRefreshed = (token: string | null) => {
+  refreshSubscribers.forEach((callback) => callback(token));
+  refreshSubscribers = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const status = error.response?.status;
+    const originalRequest = error.config as RetryableConfig | undefined;
+
+    const requestUrl = originalRequest?.url || "";
+    const isAuthRequest = [endpoints.login, endpoints.refresh].some((endpoint) =>
+      requestUrl.includes(endpoint)
+    );
+
+    if (status === 401 && originalRequest && !originalRequest._retry && !isAuthRequest) {
+      const refreshToken = getRefreshToken();
+      if (!refreshToken) {
+        clearAuthTokens();
+        return Promise.reject(error);
+      }
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          subscribeTokenRefresh((token) => {
+            if (!token) {
+              reject(error);
+              return;
+            }
+            if (!originalRequest.headers) {
+              originalRequest.headers = {};
+            }
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            resolve(apiClient(originalRequest));
+          });
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const refreshUrl = `${API_BASE_URL}${endpoints.refresh}`;
+        const response = await axios.post(refreshUrl, { refresh: refreshToken });
+        const newAccess = (response.data as { access?: string }).access;
+        const newRefresh = (response.data as { refresh?: string }).refresh;
+
+        if (newAccess) {
+          setAuthTokens(newAccess, newRefresh ?? refreshToken);
+          onRefreshed(newAccess);
+
+          if (!originalRequest.headers) {
+            originalRequest.headers = {};
+          }
+          originalRequest.headers.Authorization = `Bearer ${newAccess}`;
+
+          return apiClient(originalRequest);
+        }
+
+        clearAuthTokens();
+        onRefreshed(null);
+        return Promise.reject(error);
+      } catch (refreshError) {
+        clearAuthTokens();
+        onRefreshed(null);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export { API_BASE_URL };

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -1,8 +1,137 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { Button } from '../components/ui/custom-button';
-import { PlusIcon, TagIcon } from '@heroicons/react/24/outline';
+import { Input } from '../components/ui/custom-input';
+import { PlusIcon, TagIcon, TrashIcon, ArrowsUpDownIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient, endpoints, normalizeListResponse } from '../lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { useToast } from '../components/ui/use-toast';
+
+interface ApiCategory {
+  id: number;
+  name: string;
+  parent?: number | null;
+}
 
 export const Categories: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [effectiveSearch, setEffectiveSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const [categoryFormOpen, setCategoryFormOpen] = useState(false);
+  const [categoryForm, setCategoryForm] = useState({
+    name: '',
+    parent: '',
+  });
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery({
+    queryKey: ['categories', effectiveSearch, page],
+    queryFn: async () => {
+      const res = await apiClient.get(endpoints.categories, {
+        params: { search: effectiveSearch || undefined, page },
+      });
+      return normalizeListResponse<ApiCategory>(res.data);
+    },
+    keepPreviousData: true,
+  });
+
+  const { data: categoryOptionsData } = useQuery({
+    queryKey: ['category-options'],
+    queryFn: async () => {
+      const res = await apiClient.get(endpoints.categories);
+      return normalizeListResponse<ApiCategory>(res.data);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const list = data?.results || [];
+  const total = data?.count ?? list.length;
+  const hasNext = Boolean(data?.next);
+  const hasPrev = Boolean(data?.previous);
+
+  const optionSource = categoryOptionsData?.results || [];
+  const parentLookup = useMemo(() => {
+    const map = new Map<number, string>();
+    [...optionSource, ...list].forEach((category) => {
+      map.set(category.id, category.name);
+    });
+    return map;
+  }, [optionSource, list]);
+
+  const sortedList = useMemo(() => {
+    const categories = [...list];
+    categories.sort((a, b) => {
+      const av = a.name.toLowerCase();
+      const bv = b.name.toLowerCase();
+      if (av < bv) return sortDir === 'asc' ? -1 : 1;
+      if (av > bv) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return categories;
+  }, [list, sortDir]);
+
+  const createCategoryMutation = useMutation({
+    mutationFn: async (payload: { name: string; parent?: number | null }) => {
+      const res = await apiClient.post(endpoints.categories, payload);
+      return res.data as ApiCategory;
+    },
+    onSuccess: () => {
+      toast({ title: 'تمت الإضافة', description: 'تم إنشاء الفئة بنجاح' });
+      setCategoryFormOpen(false);
+      setCategoryForm({ name: '', parent: '' });
+      setPage(1);
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['category-options'] });
+    },
+    onError: (err: any) => {
+      const message = err?.response?.data?.detail || err?.response?.data?.error || 'تعذر إنشاء الفئة';
+      toast({ title: 'خطأ', description: message, variant: 'destructive' });
+    },
+  });
+
+  const deleteCategoryMutation = useMutation({
+    mutationFn: async ({ id }: { id: number }) => {
+      await apiClient.delete(endpoints.categoryDetail(id));
+    },
+    onSuccess: () => {
+      toast({ title: 'تم الحذف', description: 'تم حذف الفئة' });
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['category-options'] });
+    },
+    onError: (err: any) => {
+      const message = err?.response?.data?.detail || err?.response?.data?.error || 'تعذر حذف الفئة';
+      toast({ title: 'خطأ', description: message, variant: 'destructive' });
+    },
+  });
+
+  const parentOptions = useMemo(() => {
+    const optionsMap = new Map<number, string>();
+    optionSource.forEach((category) => optionsMap.set(category.id, category.name));
+    list.forEach((category) => optionsMap.set(category.id, category.name));
+    return Array.from(optionsMap.entries())
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([id, name]) => ({ id, name }));
+  }, [optionSource, list]);
+
+  const parentName = (parentId?: number | null) => {
+    if (!parentId) return '-';
+    return parentLookup.get(parentId) || `#${parentId}`;
+  };
+
+  const isDeleting = deleteCategoryMutation.isPending;
+  const deletingId = deleteCategoryMutation.variables?.id;
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -10,19 +139,192 @@ export const Categories: React.FC = () => {
           <h1 className="text-3xl font-bold text-foreground">الفئات</h1>
           <p className="text-muted-foreground mt-1">إدارة فئات المنتجات</p>
         </div>
-        <Button variant="hero" className="gap-2">
+        <Button
+          variant="hero"
+          className="gap-2"
+          onClick={() => {
+            setCategoryForm({ name: '', parent: '' });
+            setCategoryFormOpen(true);
+          }}
+        >
           <PlusIcon className="h-4 w-4" />
           إضافة فئة جديدة
         </Button>
       </div>
 
-      <div className="bg-card rounded-lg border border-border p-12 text-center">
-        <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-full flex items-center justify-center">
-          <TagIcon className="h-8 w-8 text-muted-foreground" />
+      <div className="bg-card rounded-lg border border-border p-6">
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex-1">
+            <Input
+              placeholder="البحث في الفئات..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              leftIcon={<TagIcon className="h-4 w-4" />}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setPage(1);
+                setEffectiveSearch(searchTerm.trim());
+                refetch();
+              }}
+            >
+              بحث
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))}
+              className="gap-1"
+            >
+              ترتيب <ArrowsUpDownIcon className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
-        <h3 className="text-lg font-semibold text-foreground mb-2">قريباً</h3>
-        <p className="text-muted-foreground">صفحة إدارة الفئات قيد التطوير</p>
       </div>
+
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-muted">
+              <tr>
+                <th className="text-right py-4 px-6 text-sm font-semibold text-foreground">اسم الفئة</th>
+                <th className="text-right py-4 px-6 text-sm font-semibold text-foreground">الفئة الأب</th>
+                <th className="text-right py-4 px-6 text-sm font-semibold text-foreground">الإجراءات</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading || isFetching ? (
+                <tr>
+                  <td className="py-6 px-6 text-muted-foreground" colSpan={3}>
+                    ...جاري التحميل
+                  </td>
+                </tr>
+              ) : isError ? (
+                <tr>
+                  <td className="py-6 px-6 text-destructive" colSpan={3}>
+                    تعذر جلب البيانات
+                  </td>
+                </tr>
+              ) : sortedList.length === 0 ? (
+                <tr>
+                  <td className="py-6 px-6 text-muted-foreground" colSpan={3}>
+                    لا توجد فئات مسجلة
+                  </td>
+                </tr>
+              ) : (
+                sortedList.map((category, index) => (
+                  <tr
+                    key={category.id}
+                    className={`border-b border-border ${index % 2 === 0 ? 'bg-background' : 'bg-card'}`}
+                  >
+                    <td className="py-4 px-6 text-foreground font-medium">{category.name}</td>
+                    <td className="py-4 px-6 text-muted-foreground">{parentName(category.parent)}</td>
+                    <td className="py-4 px-6">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => deleteCategoryMutation.mutate({ id: category.id })}
+                        disabled={isDeleting && deletingId === category.id}
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">الإجمالي: {total.toLocaleString()} فئة</div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasPrev || page === 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            السابق
+          </Button>
+          <span className="text-sm text-muted-foreground">صفحة {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasNext}
+            onClick={() => setPage((current) => current + 1)}
+          >
+            التالي
+          </Button>
+        </div>
+      </div>
+
+      <Dialog
+        open={categoryFormOpen}
+        onOpenChange={(open) => {
+          setCategoryFormOpen(open);
+          if (!open) {
+            setCategoryForm({ name: '', parent: '' });
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>إضافة فئة جديدة</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              label="اسم الفئة"
+              placeholder="أدخل اسم الفئة"
+              value={categoryForm.name}
+              onChange={(e) => setCategoryForm((prev) => ({ ...prev, name: e.target.value }))}
+              required
+            />
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">الفئة الأب (اختياري)</label>
+              <Select
+                value={categoryForm.parent}
+                onValueChange={(value) => setCategoryForm((prev) => ({ ...prev, parent: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="اختر الفئة الأب" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">بدون فئة أب</SelectItem>
+                  {parentOptions.map((option) => (
+                    <SelectItem key={option.id} value={String(option.id)}>
+                      {option.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setCategoryFormOpen(false); setCategoryForm({ name: '', parent: '' }); }}>
+              إلغاء
+            </Button>
+            <Button
+              onClick={() => {
+                const name = categoryForm.name.trim();
+                if (!name) return;
+                const payload: { name: string; parent?: number | null } = { name };
+                if (categoryForm.parent) {
+                  payload.parent = Number(categoryForm.parent);
+                }
+                createCategoryMutation.mutate(payload);
+              }}
+              disabled={!categoryForm.name.trim() || createCategoryMutation.isPending}
+            >
+              حفظ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Button } from '../components/ui/custom-button';
 import { Input } from '../components/ui/custom-input';
 import {
@@ -6,57 +6,144 @@ import {
   MagnifyingGlassIcon,
   EyeIcon,
   DocumentTextIcon,
-  CalendarIcon,
   CheckCircleIcon,
   ClockIcon,
   XCircleIcon,
 } from '@heroicons/react/24/outline';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient, endpoints, normalizeListResponse } from '../lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { useToast } from '../components/ui/use-toast';
 
-interface Invoice {
+interface ApiInvoiceItem {
   id: number;
-  number: string;
-  customer: string;
-  amount: number;
-  status: 'draft' | 'confirmed' | 'paid' | 'cancelled';
-  date: string;
-  items: number;
+  product_name: string;
+  product_sku?: string | null;
+  qty: string | number;
+  price_at_add: string | number;
+  line_total: string | number;
 }
 
-// Mock data
-const mockInvoices: Invoice[] = [
-  { id: 1, number: 'INV-2024-001', customer: 'أحمد محمد علي', amount: 2450.50, status: 'confirmed', date: '2024-01-15', items: 3 },
-  { id: 2, number: 'INV-2024-002', customer: 'فاطمة الزهراني', amount: 890.25, status: 'paid', date: '2024-01-14', items: 2 },
-  { id: 3, number: 'INV-2024-003', customer: 'محمد العتيبي', amount: 1200.00, status: 'draft', date: '2024-01-13', items: 1 },
-  { id: 4, number: 'INV-2024-004', customer: 'سارة القحطاني', amount: 3200.75, status: 'confirmed', date: '2024-01-12', items: 5 },
-  { id: 5, number: 'INV-2024-005', customer: 'عبدالله النجار', amount: 750.00, status: 'cancelled', date: '2024-01-11', items: 2 },
-];
+interface ApiInvoice {
+  id: number;
+  customer: number;
+  customer_name: string;
+  status: 'draft' | 'confirmed' | 'cancelled';
+  created_at: string;
+  total_amount: string | number;
+  items?: ApiInvoiceItem[];
+}
+
+interface ApiCustomerOption {
+  id: number;
+  name: string;
+}
+
+const statusConfigMap: Record<ApiInvoice['status'], { text: string; color: string; icon: typeof CheckCircleIcon }> = {
+  draft: { text: 'مسودة', color: 'text-warning bg-warning-light', icon: ClockIcon },
+  confirmed: { text: 'مؤكدة', color: 'text-primary bg-primary-light', icon: CheckCircleIcon },
+  cancelled: { text: 'ملغاة', color: 'text-destructive bg-destructive-light', icon: XCircleIcon },
+};
 
 export const Invoices: React.FC = () => {
-  const [invoices] = useState<Invoice[]>(mockInvoices);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
 
-  const filteredInvoices = invoices.filter(invoice => {
-    const matchesSearch = 
-      invoice.number.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      invoice.customer.toLowerCase().includes(searchTerm.toLowerCase());
-    
-    const matchesStatus = statusFilter === 'all' || invoice.status === statusFilter;
-    
-    return matchesSearch && matchesStatus;
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | ApiInvoice['status']>('all');
+  const [page, setPage] = useState(1);
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [selectedInvoice, setSelectedInvoice] = useState<ApiInvoice | null>(null);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [selectedCustomer, setSelectedCustomer] = useState('');
+  const [customerSearch, setCustomerSearch] = useState('');
+  const [customerSearchKeyword, setCustomerSearchKeyword] = useState('');
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ['invoices', statusFilter, page],
+    queryFn: async () => {
+      const res = await apiClient.get(endpoints.invoices, {
+        params: {
+          page,
+          status: statusFilter === 'all' ? undefined : statusFilter,
+        },
+      });
+      return normalizeListResponse<ApiInvoice>(res.data);
+    },
+    keepPreviousData: true,
   });
 
-  const getStatusConfig = (status: Invoice['status']) => {
-    const configs = {
-      draft: { text: 'مسودة', color: 'text-warning bg-warning-light', icon: ClockIcon },
-      confirmed: { text: 'مؤكدة', color: 'text-primary bg-primary-light', icon: CheckCircleIcon },
-      paid: { text: 'مدفوعة', color: 'text-success bg-success-light', icon: CheckCircleIcon },
-      cancelled: { text: 'ملغاة', color: 'text-destructive bg-destructive-light', icon: XCircleIcon },
-    };
-    return configs[status];
-  };
+  const { data: customerOptionsData, isLoading: customerOptionsLoading } = useQuery({
+    queryKey: ['invoice-customers', customerSearchKeyword],
+    queryFn: async () => {
+      const res = await apiClient.get(endpoints.customers, {
+        params: { search: customerSearchKeyword || undefined },
+      });
+      return normalizeListResponse<ApiCustomerOption>(res.data);
+    },
+    enabled: createDialogOpen,
+    keepPreviousData: true,
+  });
 
-  const totalAmount = filteredInvoices.reduce((sum, invoice) => sum + invoice.amount, 0);
+  const list = data?.results || [];
+  const total = data?.count ?? list.length;
+  const hasNext = Boolean(data?.next);
+  const hasPrev = Boolean(data?.previous);
+
+  const filteredInvoices = useMemo(() => {
+    if (!searchKeyword) return list;
+    const keyword = searchKeyword.trim().toLowerCase();
+    if (!keyword) return list;
+    return list.filter((invoice) => {
+      const idMatch = String(invoice.id).includes(keyword);
+      const customerMatch = invoice.customer_name?.toLowerCase().includes(keyword);
+      return idMatch || customerMatch;
+    });
+  }, [list, searchKeyword]);
+
+  const stats = useMemo(() => {
+    return filteredInvoices.reduce(
+      (acc, invoice) => {
+        const totalAmount = typeof invoice.total_amount === 'string'
+          ? parseFloat(invoice.total_amount)
+          : Number(invoice.total_amount || 0);
+        acc.totalAmount += Number.isNaN(totalAmount) ? 0 : totalAmount;
+        acc.count += 1;
+        acc.statusCount[invoice.status] = (acc.statusCount[invoice.status] || 0) + 1;
+        return acc;
+      },
+      { count: 0, totalAmount: 0, statusCount: { draft: 0, confirmed: 0, cancelled: 0 } as Record<ApiInvoice['status'], number> }
+    );
+  }, [filteredInvoices]);
+
+  const createInvoiceMutation = useMutation({
+    mutationFn: async ({ customerId }: { customerId: number }) => {
+      const res = await apiClient.post(endpoints.invoices, { customer: customerId });
+      return res.data as ApiInvoice;
+    },
+    onSuccess: (invoice) => {
+      toast({ title: 'تم إنشاء الفاتورة', description: `تم إنشاء فاتورة برقم #${invoice.id}` });
+      setCreateDialogOpen(false);
+      setSelectedCustomer('');
+      setCustomerSearch('');
+      setCustomerSearchKeyword('');
+      queryClient.invalidateQueries({ queryKey: ['invoices'] });
+    },
+    onError: (err: any) => {
+      const message = err?.response?.data?.detail || err?.response?.data?.error || 'تعذر إنشاء الفاتورة';
+      toast({ title: 'خطأ', description: message, variant: 'destructive' });
+    },
+  });
+
+  const customerOptions = customerOptionsData?.results || [];
 
   return (
     <div className="space-y-6">
@@ -66,7 +153,7 @@ export const Invoices: React.FC = () => {
           <h1 className="text-3xl font-bold text-foreground">الفواتير</h1>
           <p className="text-muted-foreground mt-1">إدارة فواتير المبيعات</p>
         </div>
-        <Button variant="hero" className="gap-2">
+        <Button variant="hero" className="gap-2" onClick={() => setCreateDialogOpen(true)}>
           <PlusIcon className="h-4 w-4" />
           إنشاء فاتورة جديدة
         </Button>
@@ -81,39 +168,35 @@ export const Invoices: React.FC = () => {
             </div>
             <div>
               <p className="text-sm text-muted-foreground">إجمالي الفواتير</p>
-              <p className="text-xl font-bold text-foreground">{filteredInvoices.length}</p>
+              <p className="text-xl font-bold text-foreground">{stats.count}</p>
             </div>
           </div>
         </div>
-        
+
         <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-success-light rounded-full">
               <CheckCircleIcon className="h-5 w-5 text-success" />
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">مدفوعة</p>
-              <p className="text-xl font-bold text-foreground">
-                {filteredInvoices.filter(i => i.status === 'paid').length}
-              </p>
+              <p className="text-sm text-muted-foreground">مؤكدة</p>
+              <p className="text-xl font-bold text-foreground">{stats.statusCount.confirmed}</p>
             </div>
           </div>
         </div>
-        
+
         <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-warning-light rounded-full">
               <ClockIcon className="h-5 w-5 text-warning" />
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">معلقة</p>
-              <p className="text-xl font-bold text-foreground">
-                {filteredInvoices.filter(i => i.status === 'confirmed').length}
-              </p>
+              <p className="text-sm text-muted-foreground">مسودات</p>
+              <p className="text-xl font-bold text-foreground">{stats.statusCount.draft}</p>
             </div>
           </div>
         </div>
-        
+
         <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-primary-light rounded-full">
@@ -121,9 +204,7 @@ export const Invoices: React.FC = () => {
             </div>
             <div>
               <p className="text-sm text-muted-foreground">إجمالي المبلغ</p>
-              <p className="text-xl font-bold text-foreground">
-                {totalAmount.toLocaleString()}
-              </p>
+              <p className="text-xl font-bold text-foreground">{stats.totalAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })}</p>
             </div>
           </div>
         </div>
@@ -141,20 +222,37 @@ export const Invoices: React.FC = () => {
             />
           </div>
           <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setPage(1);
+                setSearchKeyword(searchTerm.trim());
+              }}
+            >
+              بحث
+            </Button>
             <select
               value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
+              onChange={(e) => {
+                setPage(1);
+                setStatusFilter(e.target.value as typeof statusFilter);
+              }}
               className="px-3 py-2 rounded-md border border-input-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             >
               <option value="all">جميع الحالات</option>
               <option value="draft">مسودة</option>
               <option value="confirmed">مؤكدة</option>
-              <option value="paid">مدفوعة</option>
               <option value="cancelled">ملغاة</option>
             </select>
-            <Button variant="outline">
-              <CalendarIcon className="h-4 w-4 ml-2" />
-              التاريخ
+            <Button
+              variant="outline"
+              onClick={() => {
+                setPage(1);
+                setSearchTerm('');
+                setSearchKeyword('');
+              }}
+            >
+              إعادة تعيين
             </Button>
           </div>
         </div>
@@ -176,65 +274,260 @@ export const Invoices: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {filteredInvoices.map((invoice, index) => {
-                const statusConfig = getStatusConfig(invoice.status);
-                const StatusIcon = statusConfig.icon;
-                
-                return (
-                  <tr 
-                    key={invoice.id} 
-                    className={`border-b border-border hover:bg-card-hover transition-colors ${
-                      index % 2 === 0 ? 'bg-background' : 'bg-card'
-                    }`}
-                  >
-                    <td className="py-4 px-6">
-                      <span className="font-mono font-medium text-foreground">{invoice.number}</span>
-                    </td>
-                    <td className="py-4 px-6">
-                      <span className="text-foreground">{invoice.customer}</span>
-                    </td>
-                    <td className="py-4 px-6">
-                      <span className="font-semibold text-foreground">
-                        {invoice.amount.toLocaleString()} ر.س
-                      </span>
-                    </td>
-                    <td className="py-4 px-6">
-                      <span className="text-muted-foreground">{invoice.items} عنصر</span>
-                    </td>
-                    <td className="py-4 px-6">
-                      <span className="text-muted-foreground">
-                        {new Date(invoice.date).toLocaleDateString('ar')}
-                      </span>
-                    </td>
-                    <td className="py-4 px-6">
-                      <div className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-xs font-medium ${statusConfig.color}`}>
-                        <StatusIcon className="h-3 w-3" />
-                        {statusConfig.text}
-                      </div>
-                    </td>
-                    <td className="py-4 px-6">
-                      <Button variant="ghost" size="sm">
-                        <EyeIcon className="h-4 w-4" />
-                      </Button>
-                    </td>
-                  </tr>
-                );
-              })}
+              {isLoading || isFetching ? (
+                <tr>
+                  <td className="py-6 px-6 text-muted-foreground" colSpan={7}>
+                    ...جاري التحميل
+                  </td>
+                </tr>
+              ) : isError ? (
+                <tr>
+                  <td className="py-6 px-6 text-destructive" colSpan={7}>
+                    تعذر جلب البيانات
+                  </td>
+                </tr>
+              ) : filteredInvoices.length === 0 ? (
+                <tr>
+                  <td className="py-6 px-6 text-muted-foreground" colSpan={7}>
+                    لم يتم العثور على فواتير
+                  </td>
+                </tr>
+              ) : (
+                filteredInvoices.map((invoice, index) => {
+                  const statusConfig = statusConfigMap[invoice.status];
+                  const StatusIcon = statusConfig.icon;
+                  const amount = typeof invoice.total_amount === 'string'
+                    ? parseFloat(invoice.total_amount)
+                    : Number(invoice.total_amount || 0);
+                  const itemsCount = invoice.items?.length ?? 0;
+
+                  return (
+                    <tr
+                      key={invoice.id}
+                      className={`border-b border-border hover:bg-card-hover transition-colors ${
+                        index % 2 === 0 ? 'bg-background' : 'bg-card'
+                      }`}
+                    >
+                      <td className="py-4 px-6">
+                        <span className="font-mono font-medium text-foreground">فاتورة #{invoice.id}</span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <span className="text-foreground">{invoice.customer_name}</span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <span className="font-semibold text-foreground">
+                          {amount.toLocaleString(undefined, { maximumFractionDigits: 2 })} ر.س
+                        </span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <span className="text-muted-foreground">{itemsCount} عنصر</span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <span className="text-muted-foreground">
+                          {new Date(invoice.created_at).toLocaleDateString('ar')}
+                        </span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <div className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-xs font-medium ${statusConfig.color}`}>
+                          <StatusIcon className="h-3 w-3" />
+                          {statusConfig.text}
+                        </div>
+                      </td>
+                      <td className="py-4 px-6">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setSelectedInvoice(invoice);
+                            setDetailDialogOpen(true);
+                          }}
+                        >
+                          <EyeIcon className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
             </tbody>
           </table>
         </div>
-
-        {/* Empty State */}
-        {filteredInvoices.length === 0 && (
-          <div className="text-center py-12">
-            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-full flex items-center justify-center">
-              <DocumentTextIcon className="h-8 w-8 text-muted-foreground" />
-            </div>
-            <h3 className="text-lg font-semibold text-foreground mb-2">لم يتم العثور على فواتير</h3>
-            <p className="text-muted-foreground">جرب تغيير كلمات البحث أو المرشحات</p>
-          </div>
-        )}
       </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">الإجمالي: {total.toLocaleString()} فاتورة</div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasPrev || page === 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            السابق
+          </Button>
+          <span className="text-sm text-muted-foreground">صفحة {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasNext}
+            onClick={() => setPage((current) => current + 1)}
+          >
+            التالي
+          </Button>
+        </div>
+      </div>
+
+      {/* Invoice Details Dialog */}
+      <Dialog
+        open={detailDialogOpen}
+        onOpenChange={(open) => {
+          setDetailDialogOpen(open);
+          if (!open) {
+            setSelectedInvoice(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>تفاصيل الفاتورة</DialogTitle>
+          </DialogHeader>
+          {selectedInvoice ? (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-muted-foreground">رقم الفاتورة</p>
+                  <p className="text-foreground font-medium">#{selectedInvoice.id}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">العميل</p>
+                  <p className="text-foreground font-medium">{selectedInvoice.customer_name}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">الحالة</p>
+                  <div className={`inline-flex items-center gap-2 px-2 py-1 rounded-full text-xs font-medium ${statusConfigMap[selectedInvoice.status].color}`}>
+                    {statusConfigMap[selectedInvoice.status].text}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">التاريخ</p>
+                  <p className="text-foreground font-medium">
+                    {new Date(selectedInvoice.created_at).toLocaleString('ar')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="border border-border rounded-lg overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted">
+                    <tr>
+                      <th className="text-right py-3 px-4">المنتج</th>
+                      <th className="text-right py-3 px-4">الكمية</th>
+                      <th className="text-right py-3 px-4">السعر</th>
+                      <th className="text-right py-3 px-4">الإجمالي</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(selectedInvoice.items || []).map((item) => {
+                      const qty = typeof item.qty === 'string' ? parseFloat(item.qty) : Number(item.qty || 0);
+                      const price = typeof item.price_at_add === 'string' ? parseFloat(item.price_at_add) : Number(item.price_at_add || 0);
+                      const total = typeof item.line_total === 'string' ? parseFloat(item.line_total) : Number(item.line_total || 0);
+
+                      return (
+                        <tr key={item.id} className="border-b border-border last:border-b-0">
+                          <td className="py-3 px-4">
+                            <div className="flex flex-col">
+                              <span className="font-medium text-foreground">{item.product_name}</span>
+                              {item.product_sku && <span className="text-xs text-muted-foreground">SKU: {item.product_sku}</span>}
+                            </div>
+                          </td>
+                          <td className="py-3 px-4 text-muted-foreground">{qty}</td>
+                          <td className="py-3 px-4 text-muted-foreground">{price.toLocaleString()} ر.س</td>
+                          <td className="py-3 px-4 text-foreground font-medium">{total.toLocaleString()} ر.س</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center text-muted-foreground py-6">لا توجد بيانات</div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Invoice Dialog */}
+      <Dialog
+        open={createDialogOpen}
+        onOpenChange={(open) => {
+          setCreateDialogOpen(open);
+          if (!open) {
+            setSelectedCustomer('');
+            setCustomerSearch('');
+            setCustomerSearchKeyword('');
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>إنشاء فاتورة جديدة</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              label="البحث عن عميل"
+              placeholder="اكتب اسم العميل"
+              value={customerSearch}
+              onChange={(e) => setCustomerSearch(e.target.value)}
+              leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+            />
+            <Button
+              variant="outline"
+              onClick={() => setCustomerSearchKeyword(customerSearch.trim())}
+              disabled={customerOptionsLoading}
+            >
+              بحث عن عميل
+            </Button>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">اختر العميل</label>
+              <Select value={selectedCustomer} onValueChange={(value) => setSelectedCustomer(value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder={customerOptionsLoading ? '...جاري التحميل' : 'اختر العميل'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {customerOptions.map((customer) => (
+                    <SelectItem key={customer.id} value={String(customer.id)}>
+                      {customer.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setCreateDialogOpen(false);
+                setSelectedCustomer('');
+                setCustomerSearch('');
+                setCustomerSearchKeyword('');
+              }}
+            >
+              إلغاء
+            </Button>
+            <Button
+              onClick={() => {
+                if (!selectedCustomer) return;
+                createInvoiceMutation.mutate({ customerId: Number(selectedCustomer) });
+              }}
+              disabled={!selectedCustomer || createInvoiceMutation.isPending}
+            >
+              حفظ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add shared API client utilities with token handling for the React app
- hook customers, products, categories, invoices, and dashboard pages to real Django endpoints with creation dialogs
- improve authentication context to persist JWT tokens and load saved user info

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf0326315c832a986fb7d6d143ddb9